### PR TITLE
Allow registration of strategies per-control

### DIFF
--- a/src/Binda/Binder.cs
+++ b/src/Binda/Binder.cs
@@ -124,7 +124,7 @@ namespace Binda
                 var finalControlName = alias == null ? controlName : alias.Property;
                 var sourceProperty = sourceProperties.FirstOrDefault(x => string.Equals(x.Name, finalControlName, StringComparison.OrdinalIgnoreCase));
                 if (sourceProperty == null) continue;
-                var strategy = _typeStrategies[control.GetType()];
+                var strategy = GetStrategyFor(control);
                 if (source.GetType().GetInterfaces().Any(x => x == typeof(INotifyPropertyChanged)))
                     strategy.BindControl(control, source, sourceProperty.Name);
                 else
@@ -150,10 +150,18 @@ namespace Binda
                 var control = controls.FirstOrDefault(x => string.Equals(_controlPrefix == null ? x.Name : _controlPrefix.RemovePrefix(x.Name), propertyName, StringComparison.OrdinalIgnoreCase));
                 if (control == null) continue;
 
-                var strategy = _typeStrategies[control.GetType()];
+                var strategy = GetStrategyFor(control);
                 var value = strategy.GetControlValue(control);
                 property.SetValue(destination, value, null);
             }
+        }
+
+        private BindaStrategy GetStrategyFor(Control control)
+        {
+            return
+                _controlStrategies.ContainsKey(control)
+                    ? _controlStrategies[control]
+                    : _typeStrategies[control.GetType()];
         }
     }
 }

--- a/src/Binda/Binder.cs
+++ b/src/Binda/Binder.cs
@@ -116,7 +116,7 @@ namespace Binda
             aliases = aliases ?? Enumerable.Empty<BindaAlias>().ToList();
 
             var sourceProperties = source.GetType().GetProperties();
-            var controls = destination.GetAllControlsRecursive<Control>().Where(c => _typeStrategies.ContainsKey(c.GetType())).ToList();
+            var controls = GetControlsFor(destination);
             foreach (var control in controls)
             {
                 var controlName = _controlPrefix == null ? control.Name : _controlPrefix.RemovePrefix(control.Name);
@@ -138,8 +138,8 @@ namespace Binda
             if (destination == null) throw new ArgumentNullException("destination");
             aliases = aliases ?? Enumerable.Empty<BindaAlias>().ToList();
 
+            var controls = GetControlsFor(source);
             var properties = destination.GetType().GetProperties().Where(property => property.CanWrite);
-            var controls = source.GetAllControlsRecursive<Control>().Where(c => _typeStrategies.ContainsKey(c.GetType())).ToList();
             foreach (var property in properties)
             {
                 var propertyName = property.Name;
@@ -162,6 +162,17 @@ namespace Binda
                 _controlStrategies.ContainsKey(control)
                     ? _controlStrategies[control]
                     : _typeStrategies[control.GetType()];
+        }
+
+        private IList<Control> GetControlsFor(ContainerControl control)
+        {
+            return
+                control
+                    .GetAllControlsRecursive<Control>()
+                    .Where(x =>
+                        _controlStrategies.ContainsKey(x) ||
+                        _typeStrategies.ContainsKey(x.GetType()))
+                    .ToList();
         }
     }
 }

--- a/src/Binda/Binder.cs
+++ b/src/Binda/Binder.cs
@@ -9,22 +9,26 @@ namespace Binda
 {
     public class Binder
     {
-        readonly Dictionary<Type, BindaStrategy> _strategies;
+        private readonly IDictionary<Type, BindaStrategy> _typeStrategies;
+        private readonly IDictionary<Control, BindaStrategy> _controlStrategies;
+
         readonly List<ControlPrefix> _controlPrefixes;
         ControlPrefix _controlPrefix;
 
         public Binder()
         {
-            _strategies = new Dictionary<Type, BindaStrategy>
-                              {
-                                  {typeof (TextBox), new DefaultBindaStrategy("Text")},
-                                  {typeof (CheckBox), new DefaultBindaStrategy("Checked")},
-                                  {typeof (RadioButton), new DefaultBindaStrategy("Checked")},
-                                  {typeof (DateTimePicker), new DefaultBindaStrategy("Value")},
-                                  {typeof (NumericUpDown), new DefaultBindaStrategy("Value")},
-                                  {typeof (ComboBox), new ListControlBindaStrategy()},
-                                  {typeof(TreeView), new TreeViewBindaStrategy()}
-                              };
+            _typeStrategies =
+                new Dictionary<Type, BindaStrategy>
+                {
+                    {typeof (TextBox), new DefaultBindaStrategy("Text")},
+                    {typeof (CheckBox), new DefaultBindaStrategy("Checked")},
+                    {typeof (RadioButton), new DefaultBindaStrategy("Checked")},
+                    {typeof (DateTimePicker), new DefaultBindaStrategy("Value")},
+                    {typeof (NumericUpDown), new DefaultBindaStrategy("Value")},
+                    {typeof (ComboBox), new ListControlBindaStrategy()},
+                    {typeof (TreeView), new TreeViewBindaStrategy()}
+                };
+            _controlStrategies = new Dictionary<Control, BindaStrategy>();
         }
 
         /// <summary>
@@ -44,7 +48,17 @@ namespace Binda
         /// <param name="strategy"></param>
         public void AddRegistration(Type controlType, BindaStrategy strategy)
         {
-            _strategies[controlType] = strategy;
+            _typeStrategies[controlType] = strategy;
+        }
+
+        /// <summary>
+        /// Add a Custom Binda Strategy for specific controls
+        /// </summary>
+        /// <param name="strategy"></param>
+        /// <param name="controls"></param>
+        public void AddRegistration(BindaStrategy strategy, params Control[] controls)
+        {
+            Array.ForEach(controls, x => _controlStrategies[x] = strategy);
         }
 
         public void AddControlPrefix(ControlPrefix controlPrefix)
@@ -102,7 +116,7 @@ namespace Binda
             aliases = aliases ?? Enumerable.Empty<BindaAlias>().ToList();
 
             var sourceProperties = source.GetType().GetProperties();
-            var controls = destination.GetAllControlsRecursive<Control>().Where(c => _strategies.ContainsKey(c.GetType())).ToList();
+            var controls = destination.GetAllControlsRecursive<Control>().Where(c => _typeStrategies.ContainsKey(c.GetType())).ToList();
             foreach (var control in controls)
             {
                 var controlName = _controlPrefix == null ? control.Name : _controlPrefix.RemovePrefix(control.Name);
@@ -110,7 +124,7 @@ namespace Binda
                 var finalControlName = alias == null ? controlName : alias.Property;
                 var sourceProperty = sourceProperties.FirstOrDefault(x => string.Equals(x.Name, finalControlName, StringComparison.OrdinalIgnoreCase));
                 if (sourceProperty == null) continue;
-                var strategy = _strategies[control.GetType()];
+                var strategy = _typeStrategies[control.GetType()];
                 if (source.GetType().GetInterfaces().Any(x => x == typeof(INotifyPropertyChanged)))
                     strategy.BindControl(control, source, sourceProperty.Name);
                 else
@@ -125,7 +139,7 @@ namespace Binda
             aliases = aliases ?? Enumerable.Empty<BindaAlias>().ToList();
 
             var properties = destination.GetType().GetProperties().Where(property => property.CanWrite);
-            var controls = source.GetAllControlsRecursive<Control>().Where(c => _strategies.ContainsKey(c.GetType())).ToList();
+            var controls = source.GetAllControlsRecursive<Control>().Where(c => _typeStrategies.ContainsKey(c.GetType())).ToList();
             foreach (var property in properties)
             {
                 var propertyName = property.Name;
@@ -136,7 +150,7 @@ namespace Binda
                 var control = controls.FirstOrDefault(x => string.Equals(_controlPrefix == null ? x.Name : _controlPrefix.RemovePrefix(x.Name), propertyName, StringComparison.OrdinalIgnoreCase));
                 if (control == null) continue;
 
-                var strategy = _strategies[control.GetType()];
+                var strategy = _typeStrategies[control.GetType()];
                 var value = strategy.GetControlValue(control);
                 property.SetValue(destination, value, null);
             }

--- a/src/BindaTests/Helpers/TestBindaStrategy.cs
+++ b/src/BindaTests/Helpers/TestBindaStrategy.cs
@@ -1,0 +1,26 @@
+﻿using System.Windows.Forms;
+using Binda;
+
+namespace BindaTests.Helpers
+{
+    public class TestBindaStrategy : BindaStrategy
+    {
+        public bool WasBound = false;
+        public override void BindControl(Control control, object source, string propertyName)
+        {
+            WasBound = true;
+        }
+
+        public bool WasSet = false;
+        public override void SetControlValue(Control control, object source, string propertyName)
+        {
+            WasSet = true;
+        }
+
+        public object GetValue { get; set; }
+        public override object GetControlValue(Control control)
+        {
+            return GetValue;
+        }
+    }
+}

--- a/src/BindaTests/Tests/BindingFormToObjectTests.cs
+++ b/src/BindaTests/Tests/BindingFormToObjectTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Windows.Forms;
 using Binda;
+using BindaTests.Helpers;
 using BindaTests.NeededObjects;
 using NUnit.Framework;
 using Test;
@@ -43,6 +44,26 @@ namespace BindaTests.Tests
             Assert.That(post.Date, Is.EqualTo(TestVariables.Posted));
             Assert.That(post.Body, Is.EqualTo(TestVariables.Body));
             Assert.That(post.PopularityRanking, Is.EqualTo(TestVariables.PopularityRanking));
+        }
+
+
+        [Test]
+        public void When_binding_a_form_to_an_object_with_custom_control_registrations()
+        {
+            var binder = new Binder();
+            var form = NeededObjectsFactory.CreateForm();
+            var strategy = new TestBindaStrategy();
+
+            binder.AddRegistration(strategy, form.Title);
+            strategy.GetValue = "Good Title";
+
+            binder.AddRegistration(typeof (TextBox), "Text");
+            form.Title.Text = "Bad Title";
+
+            var post = new Post();
+            binder.Bind(form, post);
+
+            Assert.That(post.Title, Is.EqualTo(strategy.GetValue));
         }
 
         [Test]

--- a/src/BindaTests/Tests/BindingObjectToFormTests.cs
+++ b/src/BindaTests/Tests/BindingObjectToFormTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows.Forms;
 using Binda;
 using BindaTests.NeededObjects;
 using NUnit.Framework;
@@ -45,7 +46,23 @@ namespace BindaTests.Helpers
             Assert.That(form.PopularityRanking.PopularityRanking, Is.EqualTo(TestVariables.PopularityRanking));
         }
 
+        [Test]
+        public void When_binding_an_object_to_a_form_with_custom_control_registrations()
+        {
+            var binder = new Binder();
+            var form = new MySampleForm();
+            var strategy = new TestBindaStrategy();
 
+            binder.AddRegistration(strategy, form.Title);
+            binder.AddRegistration(typeof (TextBox), "Text");
+
+            var post = NeededObjectsFactory.CreatePost();
+            binder.Bind(post, form);
+
+            Assert.IsTrue(strategy.WasSet);
+        }
+
+        [Test]
         public void When_binding_an_object_to_aform_withaliases()
         {
             var binder = new Binder();

--- a/src/BindaTests/Tests/BindingObjectToFormTests.cs
+++ b/src/BindaTests/Tests/BindingObjectToFormTests.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 using Binda;
+using BindaTests.Helpers;
 using BindaTests.NeededObjects;
 using NUnit.Framework;
 using Test;
 
-namespace BindaTests.Helpers
+namespace BindaTests.Tests
 {
     [TestFixture]
     public class BindingObjectToFormTests

--- a/src/BindaTests/tests.csproj
+++ b/src/BindaTests/tests.csproj
@@ -101,6 +101,7 @@
     <None Include="FodyWeavers.xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Helpers\TestBindaStrategy.cs" />
     <Compile Include="Tests\BindingFormToObjectTests.cs" />
     <Compile Include="Helpers\PostWithOptionsPrefixForm.cs">
       <SubType>Form</SubType>


### PR DESCRIPTION
Previously all controls of the same type on a form had to use the same BindaStrategy.
I added an overload to `AddRegistration` which allows this more fine-grained registration.