### PR TITLE
Add a strategy for `KeyValuePair`s

### DIFF
--- a/src/Binda/Binda.csproj
+++ b/src/Binda/Binda.csproj
@@ -97,6 +97,7 @@
     <Compile Include="BindaStrategy.cs" />
     <Compile Include="Binder.cs" />
     <Compile Include="HungarianNotationControlPrefix.cs" />
+    <Compile Include="KeyValueListStrategy.cs" />
     <Compile Include="ListControlBindaStrategy.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TreeViewBindaStrategy.cs" />

--- a/src/Binda/KeyValueListStrategy.cs
+++ b/src/Binda/KeyValueListStrategy.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Windows.Forms;
+
+namespace Binda
+{
+    public class KeyValueListStrategy : ListControlBindaStrategy
+    {
+        public override void SetControlValue(Control control, object source, string propertyName)
+        {
+            ListControl listControl;
+            PropertyInfo valueProperty;
+            if ((listControl = control as ListControl) == null ||
+                (valueProperty = source.GetType().GetProperty(propertyName)) == null)
+            {
+                return;
+            }
+            var value = valueProperty.GetValue(source, null);
+
+            // DataSource == null; will reset the Display/Value Members...
+            listControl.DataSource = GetCollection(source, propertyName, value);
+            listControl.DisplayMember = "Value";
+            listControl.ValueMember = "Key";
+
+            listControl.SelectedValue = value;
+        }
+
+        public override object GetControlValue(Control control)
+        {
+            return
+                control is ListControl
+                    ? ((ListControl) control).SelectedValue
+                    : null;
+        }
+    }
+}

--- a/src/Binda/ListControlBindaStrategy.cs
+++ b/src/Binda/ListControlBindaStrategy.cs
@@ -27,7 +27,7 @@ namespace Binda
             listControl.SelectedIndex = collection.IndexOf(value);
         }
 
-        static IList GetCollection(object source, string propertyName, object value)
+        protected IList GetCollection(object source, string propertyName, object value)
         {
             var collectionPropertyName = propertyName.Pluralize();
             var collectionProperty = source.GetType().GetProperty(collectionPropertyName);

--- a/src/BindaTests/Helpers/NeededObjectsFactory.cs
+++ b/src/BindaTests/Helpers/NeededObjectsFactory.cs
@@ -17,7 +17,8 @@ namespace BindaTests
                     Body = TestVariables.Body,
                     Location = TestVariables.Location,
                     PublishStates = new BindingList<PublishState>(),
-                    Comments = new List<Comment>()
+                    Comments = new List<Comment>(),
+                    Categories = new List<KeyValuePair<int, string>>()
                 };
         }
 

--- a/src/BindaTests/Helpers/Post.cs
+++ b/src/BindaTests/Helpers/Post.cs
@@ -20,6 +20,8 @@ namespace BindaTests.NeededObjects
         public PublishState PublishState { get; set; }
         public BindingList<PublishState> PublishStates { get; set; }
         public List<Comment> Comments { get; set; }
+        public int Category { get; set; }
+        public IList<KeyValuePair<int, string>> Categories { get; set; }
     }
 
     public class PublishState

--- a/src/BindaTests/Helpers/PostWithOptionsPrefixForm.Designer.cs
+++ b/src/BindaTests/Helpers/PostWithOptionsPrefixForm.Designer.cs
@@ -44,6 +44,8 @@
             this.label6 = new System.Windows.Forms.Label();
             this.tvComments = new System.Windows.Forms.TreeView();
             this.fcPopularityRanking = new BindaTests.NeededObjects.FluxCapacitor();
+            this.cboCategory = new System.Windows.Forms.ComboBox();
+            this.lblCategory = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.nudHitCount)).BeginInit();
             this.SuspendLayout();
             // 
@@ -180,11 +182,31 @@
             this.fcPopularityRanking.Size = new System.Drawing.Size(260, 89);
             this.fcPopularityRanking.TabIndex = 20;
             // 
+            // cboCategory
+            // 
+            this.cboCategory.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboCategory.FormattingEnabled = true;
+            this.cboCategory.Location = new System.Drawing.Point(401, 105);
+            this.cboCategory.Name = "cboCategory";
+            this.cboCategory.Size = new System.Drawing.Size(198, 21);
+            this.cboCategory.TabIndex = 21;
+            // 
+            // lblCategory
+            // 
+            this.lblCategory.AutoSize = true;
+            this.lblCategory.Location = new System.Drawing.Point(401, 87);
+            this.lblCategory.Name = "lblCategory";
+            this.lblCategory.Size = new System.Drawing.Size(52, 13);
+            this.lblCategory.TabIndex = 22;
+            this.lblCategory.Text = "Category:";
+            // 
             // PostWithOptionsPrefixForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(852, 512);
+            this.Controls.Add(this.lblCategory);
+            this.Controls.Add(this.cboCategory);
             this.Controls.Add(this.fcPopularityRanking);
             this.Controls.Add(this.tvComments);
             this.Controls.Add(this.label6);
@@ -227,5 +249,7 @@
         public System.Windows.Forms.NumericUpDown nudHitCount;
         internal System.Windows.Forms.TreeView tvComments;
         internal FluxCapacitor fcPopularityRanking;
+        private System.Windows.Forms.Label lblCategory;
+        public System.Windows.Forms.ComboBox cboCategory;
     }
 }

--- a/src/BindaTests/Tests/CollectionBindingTests.cs
+++ b/src/BindaTests/Tests/CollectionBindingTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Windows.Forms;
 using Binda;
 using BindaTests.NeededObjects;
 using NUnit.Framework;
@@ -24,6 +25,26 @@ namespace BindaTests.Tests
 
             Assert.That(form.PublishState.DataSource, Is.SameAs(post.PublishStates));
             Assert.That(form.PublishState.SelectedItem, Is.SameAs(post.PublishState));
+        }
+
+        [Test]
+        public void When_binding_an_object_to_a_form_with_a_property_and_a_key_value_pair_collection()
+        {
+            var binder = new Binder();
+            binder.AddControlPrefix(new HungarianNotationControlPrefix());
+
+            var post = NeededObjectsFactory.CreatePost();
+            post.Categories.Add(new KeyValuePair<int, string>(123, "Toast"));
+            post.Categories.Add(new KeyValuePair<int, string>(8915, "Waffles"));
+            post.Categories.Add(new KeyValuePair<int, string>(56123, "Pizza"));
+            post.Category = 56123;
+
+            var form = new PostWithOptionsPrefixForm();
+            binder.AddRegistration(new KeyValueListStrategy(), form.cboCategory);
+            binder.Bind(post, form);
+
+            Assert.That(form.cboCategory.DataSource, Is.SameAs(post.Categories));
+            Assert.That(form.cboCategory.SelectedValue, Is.EqualTo(post.Category));
         }
 
 


### PR DESCRIPTION
The default ListStrategy uses SelectedItem. We need a strategy that will use SelectedValue.