### PR TITLE
Allow null values for the KeyValueStrategy

### DIFF
--- a/src/Binda/KeyValueListStrategy.cs
+++ b/src/Binda/KeyValueListStrategy.cs
@@ -16,12 +16,15 @@ namespace Binda
             }
             var value = valueProperty.GetValue(source, null);
 
-            // DataSource == null; will reset the Display/Value Members...
+            listControl.DataSource = null;
             listControl.DataSource = GetCollection(source, propertyName, value);
+            // DataSource == null; will reset the Display/Value Members...
             listControl.DisplayMember = "Value";
             listControl.ValueMember = "Key";
 
-            listControl.SelectedValue = value;
+            // NullValueException if we set SelectedValue to null. 
+            // By default it will be null since we reset the Datasource
+            if (value != null) { listControl.SelectedValue = value; }
         }
 
         public override object GetControlValue(Control control)

--- a/src/BindaTests/Helpers/NeededObjectsFactory.cs
+++ b/src/BindaTests/Helpers/NeededObjectsFactory.cs
@@ -18,7 +18,7 @@ namespace BindaTests
                     Location = TestVariables.Location,
                     PublishStates = new BindingList<PublishState>(),
                     Comments = new List<Comment>(),
-                    Categories = new List<KeyValuePair<int, string>>()
+                    Categories = new List<KeyValuePair<int?, string>>()
                 };
         }
 

--- a/src/BindaTests/Helpers/Post.cs
+++ b/src/BindaTests/Helpers/Post.cs
@@ -20,8 +20,8 @@ namespace BindaTests.NeededObjects
         public PublishState PublishState { get; set; }
         public BindingList<PublishState> PublishStates { get; set; }
         public List<Comment> Comments { get; set; }
-        public int Category { get; set; }
-        public IList<KeyValuePair<int, string>> Categories { get; set; }
+        public int? Category { get; set; }
+        public IList<KeyValuePair<int?, string>> Categories { get; set; }
     }
 
     public class PublishState

--- a/src/BindaTests/Tests/CollectionBindingTests.cs
+++ b/src/BindaTests/Tests/CollectionBindingTests.cs
@@ -34,10 +34,32 @@ namespace BindaTests.Tests
             binder.AddControlPrefix(new HungarianNotationControlPrefix());
 
             var post = NeededObjectsFactory.CreatePost();
-            post.Categories.Add(new KeyValuePair<int, string>(123, "Toast"));
-            post.Categories.Add(new KeyValuePair<int, string>(8915, "Waffles"));
-            post.Categories.Add(new KeyValuePair<int, string>(56123, "Pizza"));
+            post.Categories.Add(new KeyValuePair<int?, string>(null, "None"));
+            post.Categories.Add(new KeyValuePair<int?, string>(123, "Toast"));
+            post.Categories.Add(new KeyValuePair<int?, string>(8915, "Waffles"));
+            post.Categories.Add(new KeyValuePair<int?, string>(56123, "Pizza"));
             post.Category = 56123;
+
+            var form = new PostWithOptionsPrefixForm();
+            binder.AddRegistration(new KeyValueListStrategy(), form.cboCategory);
+            binder.Bind(post, form);
+
+            Assert.That(form.cboCategory.DataSource, Is.SameAs(post.Categories));
+            Assert.That(form.cboCategory.SelectedValue, Is.EqualTo(post.Category));
+        }
+
+        [Test]
+        public void When_binding_an_object_to_a_form_with_a_property_and_a_nullable_key_value_pair_collection()
+        {
+            var binder = new Binder();
+            binder.AddControlPrefix(new HungarianNotationControlPrefix());
+
+            var post = NeededObjectsFactory.CreatePost();
+            post.Categories.Add(new KeyValuePair<int?, string>(null, "None"));
+            post.Categories.Add(new KeyValuePair<int?, string>(123, "Toast"));
+            post.Categories.Add(new KeyValuePair<int?, string>(8915, "Waffles"));
+            post.Categories.Add(new KeyValuePair<int?, string>(56123, "Pizza"));
+            post.Category = null;
 
             var form = new PostWithOptionsPrefixForm();
             binder.AddRegistration(new KeyValueListStrategy(), form.cboCategory);


### PR DESCRIPTION
If you were binding to a dropdown using KeyValue lists and you wanted to to add a default value or the Property is Nullable WinForms throws an Exception when setting `SelectedValue = null`.

In order to get around this, the combobox is first bound to null, which makes SelectedValue null. Then it's rebound to the KeyValue list and the SelectedValue is set only if there is a Value.