### PR TITLE
Enable binding to/from any System.Windows.Forms.Control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ src/Binda/.nuget/NuGet.Config
 tools/FAKE/
 packaging/*
 src/.vs/
+src/Binda/.vs
+src/binda.tests/.vs

--- a/src/Binda/Binda.csproj
+++ b/src/Binda/Binda.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>binda</RootNamespace>
     <AssemblyName>binda</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/src/Binda/Binder.cs
+++ b/src/Binda/Binder.cs
@@ -67,69 +67,26 @@ namespace Binda
         }
 
         /// <summary>
-        /// Binds an object to a UserControl via property names including optional aliases.
+        /// Binds an object to a Control via property names including optional aliases.
         /// </summary>
         /// <param name="source">Any POCO.</param>
-        /// <param name="destination">A Windows UserControl</param>
+        /// <param name="destination">A Windows Forms Control</param>
         /// <param name="aliases">A list of BindaAliases (optional).</param>
-        public void Bind(object source, UserControl destination, IList<BindaAlias> aliases = null)
-        {
-            InternalBindToControl(source, destination, aliases);
-        }
-        /// <summary>
-        /// Binds an object to a Form via property names including optional aliases.
-        /// </summary>
-        /// <param name="source">Any POCO.</param>
-        /// <param name="destination">A Windows Form.</param>
-        /// <param name="aliases">A list of BindaAliases (optional).</param>
-        public void Bind(object source, Form destination, IList<BindaAlias> aliases = null)
-        {
-            InternalBindToControl(source, destination, aliases);
-        }
-        /// <summary>
-        /// Binds an object to a Panel via property names including optional aliases.
-        /// </summary>
-        /// <param name="source">Any POCO.</param>
-        /// <param name="destination">A Windows Panel.</param>
-        /// <param name="aliases">A list of BindaAliases (optional).</param>
-        public void Bind(object source, Panel destination, IList<BindaAlias> aliases = null)
+        public void Bind(object source, Control destination, IList<BindaAlias> aliases = null)
         {
             InternalBindToControl(source, destination, aliases);
         }
 
         /// <summary>
-        /// Binds a UserControl to an object via property names including optional aliases.
+        /// Binds a Control to an object via property names including optional aliases.
         /// </summary>
-        /// <param name="source">A Windows UserControl.</param>
+        /// <param name="source">A Windows Forms Control.</param>
         /// <param name="destination">Any POCO.</param>
         /// <param name="aliases">A list of BindaAliases (optional).</param>
-        public void Bind(UserControl source, object destination, IList<BindaAlias> aliases = null)
+        public void Bind(Control source, object destination, IList<BindaAlias> aliases = null)
         {
             InternalBindToObject(source, destination, aliases);
         }
-
-        /// <summary>
-        /// Binds a Form to an object via property names including optional aliases.
-        /// </summary>
-        /// <param name="source">A Windows Form.</param>
-        /// <param name="destination">Any POCO.</param>
-        /// <param name="aliases">A list of BindaAlias (optional).</param>
-        public void Bind(Form source, object destination, IList<BindaAlias> aliases = null)
-        {
-            InternalBindToObject(source, destination, aliases);
-        }
-
-        /// <summary>
-        /// Binds a Panel to an object via property names including optional aliases.
-        /// </summary>
-        /// <param name="source">A Windows Panel.</param>
-        /// <param name="destination">Any POCO.</param>
-        /// <param name="aliases">A list of BindaAlias (optional).</param>
-        public void Bind(Panel source, object destination, IList<BindaAlias> aliases = null)
-        {
-            InternalBindToObject(source, destination, aliases);
-        }
-
 
         private void InternalBindToControl(object source, Control destination, IList<BindaAlias> aliases)
         {

--- a/src/binda.tests/App.config
+++ b/src/binda.tests/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/>
     </startup>
 </configuration>

--- a/src/binda.tests/Properties/Resources.Designer.cs
+++ b/src/binda.tests/Properties/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace binda.tests.Properties
-{
-
-
+namespace binda.tests.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,51 +19,43 @@ namespace binda.tests.Properties
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources
-    {
-
+    internal class Resources {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources()
-        {
+        internal Resources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if ((resourceMan == null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("binda.tests.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }

--- a/src/binda.tests/Properties/Settings.Designer.cs
+++ b/src/binda.tests/Properties/Settings.Designer.cs
@@ -8,21 +8,17 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace binda.tests.Properties
-{
-
-
+namespace binda.tests.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.13.0.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
             }
         }

--- a/src/binda.tests/binda.tests.csproj
+++ b/src/binda.tests/binda.tests.csproj
@@ -8,9 +8,10 @@
     <OutputType>Library</OutputType>
     <RootNamespace>binda.tests</RootNamespace>
     <AssemblyName>binda.tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -114,6 +115,7 @@
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
+      <DesignTime>True</DesignTime>
     </Compile>
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">


### PR DESCRIPTION
These changes remove the restrictions on the types of controls that can be bound to allow any `System.Windows.Forms.Control`, enabling the use of things like DevExpress controls. 